### PR TITLE
Move menu/buttons with snackbar

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,6 +24,7 @@ android {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0-alpha01"
+    implementation "com.google.android.material:material:1.1.0-alpha01"
 }
 
 apply from: '../gradle-mvn-push.gradle'

--- a/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
@@ -1325,23 +1325,22 @@ public class FloatingActionButton extends AppCompatImageButton {
      * is to move {@link FloatingActionButton} views so that any displayed {@link Snackbar}s do
      * not cover them.
      */
-    public static class Behavior extends CoordinatorLayout.Behavior<FloatingActionButton> {
+    public static class Behavior<T extends View> extends CoordinatorLayout.Behavior<T> {
         @Override
-        public boolean layoutDependsOn(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+        public boolean layoutDependsOn(CoordinatorLayout parent, T child, View dependency) {
             return dependency instanceof Snackbar.SnackbarLayout;
         }
 
         @Override
-        public boolean onDependentViewChanged(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+        public boolean onDependentViewChanged(CoordinatorLayout parent, T child, View dependency) {
             float translationY = Math.min(0, ViewCompat.getTranslationY(dependency) - dependency.getHeight());
             ViewCompat.setTranslationY(child, translationY);
             return true;
         }
 
         @Override
-        public void onDependentViewRemoved(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+        public void onDependentViewRemoved(CoordinatorLayout parent, T child, View dependency) {
             ViewCompat.animate(child).translationY(0).start();
-
         }
     }
 }

--- a/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
@@ -26,8 +26,6 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.SystemClock;
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.AppCompatImageButton;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -38,6 +36,14 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.TextView;
 
+import com.google.android.material.snackbar.Snackbar;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
+
+@CoordinatorLayout.DefaultBehavior(FloatingActionButton.Behavior.class)
 public class FloatingActionButton extends AppCompatImageButton {
 
     public static final int SIZE_NORMAL = 0;
@@ -1312,5 +1318,30 @@ public class FloatingActionButton extends AppCompatImageButton {
 
     public void setLabelTextColor(ColorStateList colors) {
         getLabelView().setTextColor(colors);
+    }
+
+    /**
+     * Behavior designed for use with {@link FloatingActionButton} instances. Its main function
+     * is to move {@link FloatingActionButton} views so that any displayed {@link Snackbar}s do
+     * not cover them.
+     */
+    public static class Behavior extends CoordinatorLayout.Behavior<FloatingActionButton> {
+        @Override
+        public boolean layoutDependsOn(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+            return dependency instanceof Snackbar.SnackbarLayout;
+        }
+
+        @Override
+        public boolean onDependentViewChanged(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+            float translationY = Math.min(0, ViewCompat.getTranslationY(dependency) - dependency.getHeight());
+            ViewCompat.setTranslationY(child, translationY);
+            return true;
+        }
+
+        @Override
+        public void onDependentViewRemoved(CoordinatorLayout parent, FloatingActionButton child, View dependency) {
+            ViewCompat.animate(child).translationY(0).start();
+
+        }
     }
 }

--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -27,6 +27,9 @@ import android.widget.ImageView;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+@CoordinatorLayout.DefaultBehavior(FloatingActionButton.Behavior.class)
 public class FloatingActionMenu extends ViewGroup {
 
     private static final int ANIMATION_DURATION = 300;

--- a/sample/src/main/java/com/github/clans/fab/sample/HomeFragment.java
+++ b/sample/src/main/java/com/github/clans/fab/sample/HomeFragment.java
@@ -14,6 +14,7 @@ import android.widget.ListView;
 
 import com.github.clans.fab.FloatingActionButton;
 import com.github.fab.sample.R;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,6 +75,13 @@ public class HomeFragment extends Fragment {
                     mFab.show(true);
                 }
                 mPreviousVisibleItem = firstVisibleItem;
+            }
+        });
+
+        mFab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Snackbar.make(mFab, "Replace with your own action", Snackbar.LENGTH_SHORT).show();
             }
         });
     }

--- a/sample/src/main/java/com/github/clans/fab/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/clans/fab/sample/MainActivity.java
@@ -59,6 +59,9 @@ public class MainActivity extends AppCompatActivity {
                 case R.id.progress:
                     fragment = new ProgressFragment();
                     break;
+                case R.id.snackbar_fab:
+                    fragment = new SnackbarFragment();
+                    break;
             }
 
             ft.replace(R.id.fragment, fragment).commit();

--- a/sample/src/main/java/com/github/clans/fab/sample/SnackbarFragment.java
+++ b/sample/src/main/java/com/github/clans/fab/sample/SnackbarFragment.java
@@ -1,0 +1,58 @@
+package com.github.clans.fab.sample;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import com.github.clans.fab.FloatingActionButton;
+import com.github.clans.fab.FloatingActionMenu;
+import com.github.fab.sample.R;
+import com.google.android.material.snackbar.Snackbar;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class SnackbarFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.snackbar_fragment, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Locale[] availableLocales = Locale.getAvailableLocales();
+        List<String> locales = new ArrayList<>();
+        for (Locale locale : availableLocales) {
+            locales.add(locale.getDisplayName());
+        }
+
+        ListView mListView = view.findViewById(R.id.list);
+        mListView.setAdapter(new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1,
+                android.R.id.text1, locales));
+
+        final FloatingActionMenu mFabMenu = view.findViewById(R.id.snackbar_fab);
+
+        FloatingActionButton snackbarFab = new FloatingActionButton(getActivity());
+        snackbarFab.setLabelText("Click to show snackbar");
+        snackbarFab.setImageResource(R.drawable.ic_edit);
+        snackbarFab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Snackbar.make(mFabMenu, "Replace with your own action", Snackbar.LENGTH_SHORT).show();
+            }
+        });
+        mFabMenu.addMenuButton(snackbarFab);
+    }
+}

--- a/sample/src/main/res/layout/home_fragment.xml
+++ b/sample/src/main/res/layout/home_fragment.xml
@@ -4,19 +4,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ListView
-        android:id="@+id/list"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
 
-    <com.github.clans.fab.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:layout_marginBottom="12dp"
-        android:layout_marginRight="16dp"
-        android:src="@drawable/ic_menu"
-        app:fab_elevationCompat="4dp" />
+        <ListView
+            android:id="@+id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
+        <com.github.clans.fab.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:layout_marginBottom="12dp"
+            android:layout_marginRight="16dp"
+            android:src="@drawable/ic_menu"
+            app:fab_elevationCompat="4dp" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </FrameLayout>

--- a/sample/src/main/res/layout/snackbar_fragment.xml
+++ b/sample/src/main/res/layout/snackbar_fragment.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:fab="http://schemas.android.com/apk/res-auto">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ListView
+            android:id="@+id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.github.clans.fab.FloatingActionMenu
+            android:id="@+id/snackbar_fab"
+            fab:menu_fab_size="normal"
+            fab:menu_icon="@drawable/fab_add"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:layout_marginBottom="8dp"
+            android:layout_marginRight="10dp"
+            fab:menu_labels_position="left"
+            fab:elevation="4dp"
+            fab:menu_openDirection="up"
+            fab:menu_backgroundColor="@android:color/transparent"/>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>

--- a/sample/src/main/res/menu/menu_drawer.xml
+++ b/sample/src/main/res/menu/menu_drawer.xml
@@ -16,6 +16,11 @@
             android:id="@+id/progress"
             android:icon="@drawable/ic_nav_item"
             android:title="Progress" />
+        <item
+            android:id="@+id/snackbar_fab"
+            android:icon="@drawable/ic_nav_item"
+            android:title="Snackbar"
+            android:visible="true"/>
     </group>
 
 </menu>


### PR DESCRIPTION
Original pull request [#394](https://github.com/Clans/FloatingActionButton/pull/394) and [#395](https://github.com/Clans/FloatingActionButton/pull/395). Home fragment is modified to show a snackbar and move the button up(via CoordinatorLayout). I added a "snackbar fragment" to the drawer to test that the snackbar also moves the floating action menu up. 